### PR TITLE
Fix for #6

### DIFF
--- a/nmi_mysql/nmi_mysql.py
+++ b/nmi_mysql/nmi_mysql.py
@@ -109,16 +109,13 @@ class DB():
 
         self.handle.commit()
 
-    def handle_val(self, temp):
-        if isinstance(temp, str):
+    def to_string(self, temp):        
+        if isinstance(temp, (list, tuple)):
+            _tmp = ', '.join([self.to_string(t) for t in temp])
+            return '(' + _tmp + ')' if isinstance(temp, tuple) else _tmp
+        
+        elif isinstance(temp, str):
             return self.handle.escape(temp.replace('%', '%%'))
 
         else:
             return self.handle.escape(temp)
-
-    def to_string(self, temp):        
-        if isinstance(temp, (list, tuple)):
-            _tmp = ', '.join([self.handle_val(t) for t in temp])
-            return '(' + _tmp + ')' if isinstance(temp, tuple) else _tmp
-        
-        return self.handle_val(temp)


### PR DESCRIPTION
1. Adjust error handling to log error and generated query for easier debugging
2. Adjust so exception is thrown when actual error happens, instead of relying on client's check for zero modified rows
3. Rewrite query generation to make sure nested objects are properly serialized and % is properly escaped.
